### PR TITLE
Added support for attributes in method find of DiDOM\Document class. …

### DIFF
--- a/src/DiDom/Attribute.php
+++ b/src/DiDom/Attribute.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace DiDom;
+
+/**
+ * @todo create interface for attribute classes
+ */
+class Attribute extends Node
+{
+    /**
+     * @var \DOMAttr
+     */
+    protected $node;
+    /**
+     * @var Element
+     */
+    protected $ownerElement;
+
+    /**
+     * Constructor
+     *
+     * @param \DOMAttr $domAttr
+     */
+    public function __construct(\DOMAttr $domAttr)
+    {
+        parent::__construct($domAttr);
+    }
+
+    /**
+     * Returns owner element for this node
+     *
+     * @return Element
+     */
+    public function getOwner()
+    {
+        if (!$this->ownerElement && $this->node->ownerElement)
+            $this->ownerElement = new Element($this->node->ownerElement);
+
+        return $this->ownerElement;
+    }
+
+    /**
+     * Returns the text content of this node
+     *
+     * @return string
+     */
+    public function text()
+    {
+        return $this->node->value;
+    }
+}

--- a/src/DiDom/Document.php
+++ b/src/DiDom/Document.php
@@ -244,7 +244,9 @@ class Document
 
         if ($wrapElement) {
             foreach ($nodeList as $node) {
-                $elements[] = new Element($node);
+                $elements[] = $node instanceof \DOMElement ?
+                    new Element($node) :
+                    new Attribute($node);
             }
         } else {
             foreach ($nodeList as $node) {

--- a/src/DiDom/Element.php
+++ b/src/DiDom/Element.php
@@ -5,7 +5,7 @@ namespace DiDom;
 use DOMDocument;
 use InvalidArgumentException;
 
-class Element
+class Element extends Node
 {
     /**
      * The DOM element instance.
@@ -37,6 +37,8 @@ class Element
         foreach ($attributes as $name => $value) {
             $this->setAttribute($name, $value);
         }
+
+        parent::__construct($node);
     }
 
     /**
@@ -172,16 +174,6 @@ class Element
     public function xml()
     {
         return $this->toDocument()->xml();
-    }
-
-    /**
-     * Get the text content of this node and its descendants.
-     * 
-     * @return string The node value
-     */
-    public function text()
-    {
-        return $this->node->textContent;
     }
 
     /**

--- a/src/DiDom/Node.php
+++ b/src/DiDom/Node.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace DiDom;
+
+/**
+ * Base class for all nodes
+ */
+abstract class Node implements NodeInterface
+{
+    /**
+     * @var \DOMNode
+     */
+    protected $node;
+
+    /**
+     * Constructor
+     *
+     * @param \DOMNode $domNode
+     */
+    public function __construct(\DOMNode $domNode)
+    {
+        $this->node = $domNode;
+    }
+
+    /**
+     * Returns the name of this node
+     *
+     * @return string
+     */
+    public function name()
+    {
+        return $this->node->nodeName;
+    }
+
+    /**
+     * Returns the text content of this node
+     *
+     * @return string
+     */
+    public function text()
+    {
+        return $this->node->textContent;
+    }
+}

--- a/src/DiDom/NodeInterface.php
+++ b/src/DiDom/NodeInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace DiDom;
+
+/**
+ * Interface for all nodes
+ */
+interface NodeInterface
+{
+    /**
+     * Returns the name of this node
+     *
+     * @return string
+     */
+    public function name();
+
+    /**
+     * Returns the text content of this node
+     *
+     * @return string
+     */
+    public function text();
+}

--- a/tests/DiDom/AttributeTest.php
+++ b/tests/DiDom/AttributeTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\DiDom;
+
+use DiDom\Attribute;
+use DiDom\Element;
+use Tests\TestCase;
+
+class AttributeTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $name = 'testName';
+        $value = 'testValue';
+
+        $attribute = new Attribute(new \DOMAttr($name, $value));
+
+        $this->assertEquals($name, $attribute->name());
+        $this->assertEquals($value, $attribute->text());
+    }
+
+    public function testGetUnknownOwner()
+    {
+        $name = 'testName';
+        $value = 'testValue';
+
+        $domAttr = new \DOMAttr($name, $value);
+        $attribute = new Attribute($domAttr);
+
+        $this->assertNull($attribute->getOwner());
+    }
+
+    public function testGetOwner()
+    {
+        $attributeName = 'name';
+        $attributeValue = 'email';
+
+        $node = $this->createNode('input', '', [$attributeName => $attributeValue]);
+
+        $element = new Element($node);
+        $attribute = new Attribute($node->getAttributeNode($attributeName));
+
+        $owner = $attribute->getOwner();
+
+        $this->assertEquals($element->__toString(), $owner->__toString());
+    }
+}

--- a/tests/DiDom/DocumentTest.php
+++ b/tests/DiDom/DocumentTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\DiDom;
 
+use DiDom\Attribute;
 use Tests\TestCase;
 use DiDom\Document;
 use DiDom\Query;
@@ -383,5 +384,32 @@ class DocumentTest extends TestCase
         foreach ($elements as $element) {
             $this->assertInstanceOf('DiDom\Element', $element);
         }
+    }
+
+    /**
+     * @dataProvider elementsAndAttributes
+     */
+    public function testFindElementsAndAttributes($html, $xpath, $value, $type)
+    {
+        $document = new Document($html, false);
+        $elements = $document->xpath($xpath);
+
+        foreach ($elements as $element) {
+            $this->assertInstanceOf($type, $element);
+
+            if ($element instanceof Attribute)
+                $this->assertEquals($value, $element->text());
+        }
+    }
+
+    public function elementsAndAttributes()
+    {
+        $html = $this->loadFixture('form.html');
+
+        return array(
+            array($html, "//form", null, 'DiDOM\Element'),
+            array($html, "//form/@enctype", 'multipart/form-data', 'DiDOM\Attribute'),
+            array($html, "//*[@id=email]/@type", 'text', 'DiDOM\Attribute')
+        );
     }
 }

--- a/tests/fixtures/form.html
+++ b/tests/fixtures/form.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title></title>
+</head>
+<body>
+    <h1>Form</h1>
+    <form name="test-form" enctype="multipart/form-data" method="post" action="/">
+        <div>
+            <label for="email">Your email</label>
+            <input type="text" name="email" value="" id="email" />
+        </div>
+        <div>
+            <input type="submit" name="save" value="Save" />
+        </div>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
…XPath supports the following syntax: //*[@id=email]/@type. As a result will be returned instance of DOMAttr class.