### PR TITLE
add '@' after file_get_contents() function

### DIFF
--- a/src/DiDom/Document.php
+++ b/src/DiDom/Document.php
@@ -296,7 +296,7 @@ class Document
             }
         }
 
-        $content = file_get_contents($filepath);
+        $content = @file_get_contents($filepath);
 
         if ($content === false) {
             throw new RuntimeException(sprintf('Could not load file %s', $filepath));


### PR DESCRIPTION
add '@' after 'file_get_contents()' PHP function to avoid that this function throw the 'normal' fatal exception (see: http://php.net/manual/en/function.file-get-contents.php).