### PR TITLE
Fix hasAttribute issue for DOMComment and DOMText

### DIFF
--- a/src/DiDom/Element.php
+++ b/src/DiDom/Element.php
@@ -454,7 +454,7 @@ class Element
      */
     public function hasAttribute($name)
     {
-        return $this->node->hasAttribute($name);
+        return $this->isElementNode() && $this->node->hasAttribute($name);
     }
 
     /**


### PR DESCRIPTION
The `hasAttribute` method of `Element` class throws 'Call to undefined method' error if the `$node` property is an instance of `DOMComment` or `DOMText`.
Same issue happens with `setAttribute` and `removeAttribute` methods but I'm not sure whether to throw an Exception or just ignore the error if it happens and return `null`?