### PR TITLE
Fix deprecation notice in PHP 8 for libxml_disable_entity_loader

### DIFF
--- a/src/DiDom/Errors.php
+++ b/src/DiDom/Errors.php
@@ -20,7 +20,10 @@ class Errors
     public static function disable()
     {
         self::$internalErrors = libxml_use_internal_errors(true);
-        self::$disableEntities = libxml_disable_entity_loader(true);
+
+        if (\LIBXML_VERSION < 20900) {
+            self::$disableEntities = libxml_disable_entity_loader(true);
+        }
     }
 
     /**
@@ -35,6 +38,9 @@ class Errors
         }
 
         libxml_use_internal_errors(self::$internalErrors);
-        libxml_disable_entity_loader(self::$disableEntities);
+
+        if (\LIBXML_VERSION < 20900) {
+            libxml_disable_entity_loader(self::$disableEntities);
+        }
     }
 }


### PR DESCRIPTION
PHP 8 [deprecates `libxml_disable_entity_loader`](https://php.watch/versions/8.0/libxml_disable_entity_loader-deprecation) function, and this fixes the deprecation notice by not calling the function on libxml 2.9, where external entity loader is disabled by default and is not necessary to explicitly disable it.