### PR TITLE
Add a .gitattributes file with export-ignore rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Exclude build/test files from archive
+/tests            export-ignore
+/.editorconfig    export-ignore
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/.php_cs          export-ignore
+/.travis.yml      export-ignore
+/phpunit.xml      export-ignore


### PR DESCRIPTION
Adds a new [`.gitattributes` file](https://php.watch/articles/composer-gitattributes) with `export-ignore` rules for tests and build files, which reduces the current package download size by ~40% when the zip packages (`--prefer-dist`) are downloaded.