### PR TITLE
Add support for extra xml namespaces

### DIFF
--- a/src/DiDom/Document.php
+++ b/src/DiDom/Document.php
@@ -41,6 +41,13 @@ class Document
     protected $encoding;
 
     /**
+     * @var array
+     */
+    protected $namespaces = [
+        'php' => 'http://php.net/xpath'
+    ];
+
+    /**
      * @param string|null $string An HTML or XML string or a file path
      * @param bool $isFile Indicates that the first parameter is a path to a file
      * @param string $encoding The document encoding
@@ -552,10 +559,34 @@ class Document
     {
         $xpath = new DOMXPath($this->document);
 
-        $xpath->registerNamespace('php', 'http://php.net/xpath');
+        foreach ($this->namespaces as $prefix => $namespace) {
+            $xpath->registerNamespace($prefix, $namespace);
+        }
+
         $xpath->registerPhpFunctions();
 
         return $xpath;
+    }
+
+    /**
+     * Add namespace
+     *
+     * @param string $prefix
+     * @param string $namespace
+     *
+     * @return void
+     */
+    public function addNamespace($prefix, $namespace)
+    {
+        if ( ! is_string($prefix)) {
+            throw new InvalidArgumentException(sprintf('%s expects parameter 2 to be string, %s given', __METHOD__, (is_object($prefix) ? get_class($prefix) : gettype($prefix))));
+        }
+
+        if ( ! is_string($namespace)) {
+            throw new InvalidArgumentException(sprintf('%s expects parameter 2 to be string, %s given', __METHOD__, (is_object($namespace) ? get_class($namespace) : gettype($namespace))));
+        }
+
+        $this->namespaces[$prefix] = $namespace;
     }
 
     /**

--- a/src/DiDom/Document.php
+++ b/src/DiDom/Document.php
@@ -569,14 +569,12 @@ class Document
     }
 
     /**
-     * Add namespace
+     * Register a namespace.
      *
      * @param string $prefix
      * @param string $namespace
-     *
-     * @return void
      */
-    public function addNamespace($prefix, $namespace)
+    public function registerNamespace($prefix, $namespace)
     {
         if ( ! is_string($prefix)) {
             throw new InvalidArgumentException(sprintf('%s expects parameter 2 to be string, %s given', __METHOD__, (is_object($prefix) ? get_class($prefix) : gettype($prefix))));


### PR DESCRIPTION
Hi!
First of all thank you for a great component! I use it all the time.

Today in stumbled on an issue when trying to parse a sitemap xml:

```php
// example taken from https://www.google.com/sitemaps/protocol.html#sitemapXMLExample
$page = <<<TAG
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
      <loc>http://www.example.com/</loc>
      <lastmod>2005-01-01</lastmod>
      <changefreq>monthly</changefreq>
      <priority>0.8</priority>
   </url>
   <url>
      <loc>http://www.example.com/catalog?item=12&amp;desc=vacation_hawaii</loc>
      <changefreq>weekly</changefreq>
   </url>
   <url>
      <loc>http://www.example.com/catalog?item=73&amp;desc=vacation_new_zealand</loc>
      <lastmod>2004-12-23</lastmod>
      <changefreq>weekly</changefreq>
   </url>
</urlset>
TAG;

// parse sitemap
$document = new Document($page, false, 'UTF-8', Document::TYPE_XML);

$document->addNamespace('xsi', 'http://www.sitemaps.org/schemas/sitemap/0.9');

$elements = $document->find('//xsi:url/xsi:loc', Query::TYPE_XPATH);

foreach ($elements as $element) {
    echo($element->text() ."\n");
}
```

I couldn't solve the issue without adding a new method to Document so it supports adding namespaces.
I believe it will also fix this issue https://github.com/Imangazaliev/DiDOM/issues/154

Thank you for taking the time to review my pull request.
