### PR TITLE
Improve PHPunit version and usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-iconv": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8.36"
     },
     "autoload": {
         "psr-4": {
@@ -25,7 +25,7 @@
         }
     },
     "autoload-dev": {
-        "psr-4": { 
+        "psr-4": {
             "DiDom\\Tests\\": "tests/"
         }
     },

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,11 +2,11 @@
 
 namespace DiDom\Tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use DOMDocument;
 use Exception;
 
-class TestCase extends PHPUnit_Framework_TestCase
+class TestCase extends PHPUnitTestCase
 {
     protected function loadFixture($filename)
     {


### PR DESCRIPTION
# Changed log

- To be compatible with latest PHPUnit version, it can use the `PHPUnit:^4.8.36` version and `PHPUnit\Framework\TestCase` namespace to complete that.