### PR TITLE
[PHP 8.2] Avoid Mbstring `HTML-ENTITIES` deprecation

### DIFF
--- a/src/DiDom/Encoder.php
+++ b/src/DiDom/Encoder.php
@@ -13,7 +13,18 @@ class Encoder
     public static function convertToHtmlEntities($string, $encoding)
     {
         if (function_exists('mb_convert_encoding')) {
-            return mb_convert_encoding($string, 'HTML-ENTITIES', $encoding);
+            /*
+            Since PHP 8.2, 'HTML-Entities' mbstring encoder is deprecated.
+            htmlentities() is similar to 'HTML-Entities' encoding, however,
+            it encodes <>'"& characters that we do not need to be encoded.
+            htmlspecialchars_decode() decodes these special characters,
+            which result in an HTML-Entities equivalent.
+            @see https://php.watch/versions/8.2/mbstring-qprint-base64-uuencode-html-entities-deprecated#html
+            */
+
+            $encoded = mb_convert_encoding($string, 'UTF-8', $encoding);
+            $encoded = htmlentities($encoded);
+            return htmlspecialchars_decode($encoded);
         }
 
         if ('UTF-8' !== $encoding) {


### PR DESCRIPTION
In PHP 8.2, using the [Base64, Uuencode, QPrint, and HTML Entity encodings are deprecated](https://php.watch/versions/8.2/mbstring-qprint-base64-uuencode-html-entities-deprecated#html)

There is one usage of the deprecated `HTML-ENTITIES` Mbstring encoder in `\DiDom\Encoder::convertToHtmlEntities()`, which relies on the buggy behavior of `HTML-ENTITIES` encoder, which does _not_ encode characters that the `htmlspecialchars` function encodes.

This patch updates the direct `HTML-ENTITIES` encoding with three steps:

 1. Encodes the string to UTF-8 from the given encoding `$encoding`
 2. Encodes all HTML entities using `htmlentities`
 3. Decodes special chars (`<>'"&`) using `htmlspecialchars`

Thank you.