### PR TITLE
[PHP 8.4] Fixes for implicit nullability deprecation

### DIFF
--- a/src/DiDom/Document.php
+++ b/src/DiDom/Document.php
@@ -251,7 +251,7 @@ class Document
      * @throws InvalidArgumentException if parameter 4 is not an integer or null
      * @throws RuntimeException if the document type is invalid (not Document::TYPE_HTML or Document::TYPE_XML)
      */
-    public function load(string $string, bool $isFile = false, string $type = Document::TYPE_HTML, int $options = null): void
+    public function load(string $string, bool $isFile = false, string $type = Document::TYPE_HTML, ?int $options = null): void
     {
         if ( ! in_array(strtolower($type), [Document::TYPE_HTML, Document::TYPE_XML], true)) {
             throw new RuntimeException(sprintf('Document type must be "xml" or "html", %s given.', $type));

--- a/src/DiDom/Element.php
+++ b/src/DiDom/Element.php
@@ -281,7 +281,7 @@ class Element extends Node
      *
      * @return array|null
      */
-    public function attributes(array $names = null): ?array
+    public function attributes(?array $names = null): ?array
     {
         if ( ! $this->node instanceof DOMElement) {
             return null;


### PR DESCRIPTION
Fixes all issues that emits a deprecation notice on PHP 8.4.

See:
 - [RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
 - [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)